### PR TITLE
Added restart REPL command and set current working directory allowing use of use "*.sml"

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -14,8 +14,10 @@ function activate(context) {
 	console.log('Congratulations, your extension "sml-environment" is now active!');
 	
 	let execShortText = vscode.commands.registerCommand('sml-environment.executeSelected', () => smlEnviron.execShortCode());
+	let restartRepl = vscode.commands.registerCommand('sml-environment.restartRepl', () => smlEnviron.restartREPL());
 	
-	context.subscriptions.push(execShortText);	
+	context.subscriptions.push(execShortText);
+	context.subscriptions.push(restartRepl);	
 }
 exports.activate = activate;
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
 			{
 				"command": "sml-environment.executeSelected",
 				"title": "Execute selected code"
+			},
+			{
+				"command": "sml-environment.restartRepl",
+				"title": "Restart SML REPL"
 			}
 		],
 		"keybindings": [

--- a/smlEnvironmentManager.js
+++ b/smlEnvironmentManager.js
@@ -5,28 +5,45 @@ let sml;
 const smlOutput = vscode.window.createOutputChannel("SML");
 let allowNextCommand;
 
-function start(){
+function start() {
 	allowNextCommand = false;
-	const interpreter = vscode.workspace.getConfiguration().get("sml-environment-interpreter-path","sml")
-	sml = spawn(interpreter, [], {shell: true});
-	
+	const interpreter = vscode.workspace.getConfiguration().get("sml-environment-interpreter-path", "sml")
+
+	var cwd = {};
+	if (vscode.workspace.workspaceFolders !== undefined) {
+		var wd = vscode.workspace.workspaceFolders[0].uri.path;
+
+		//may start with / for some reason
+		if(wd[0] === '/')
+			wd = wd.substr(1, cwd.length);
+
+		console.log("setting path to: " + wd)
+
+		cwd = {cwd: wd};
+	}
+	else {
+		console.log("Unable to set working directory, no current workspace folder")
+	}
+
+	sml = spawn(interpreter, [], Object.assign({ shell: true }, cwd));
+
 	sml.stdin.setEncoding('utf-8');
 	sml.stdout.setEncoding('utf-8');
 	sml.stderr.setEncoding('utf-8');
 	console.log('started');
 	sml.stdin.read(0);
-	
+
 	sml.on('error', function (err) {
 		console.log(err);
 		smlOutput.append(err.message)
 	})
-	
+
 	sml.stderr.on('data', (data) => {
 		smlOutput.show(false);
 		smlOutput.append(data + `\n`);
 		allowNextCommand = true;
 	});
-	
+
 	sml.stdout.on('data', (data) => {
 		smlOutput.show(false);
 		smlOutput.append(data + `\n`);
@@ -34,8 +51,8 @@ function start(){
 	smlOutput.show(false);
 }
 
-async function execShortCode(){
-	while(!sml && !allowNextCommand){;}
+async function execShortCode() {
+	while (!sml && !allowNextCommand) { ; }
 	const editor = vscode.window.activeTextEditor;
 
 	if (editor) {
@@ -43,25 +60,35 @@ async function execShortCode(){
 		const selection = editor.selection;
 
 		const code = document.getText(selection);
-		if(sml.exitCode===0 || sml.exitCode) 
+		if (sml.exitCode === 0 || sml.exitCode)
 			vscode.window.showErrorMessage("SML process died")
 		else {
 			try {
 				allowNextCommand = false;
-				sml.stdin.write(code+';');			
+				sml.stdin.write(code + ';');
 			} catch (error) {
-				smlOutput.append(error.message)			
+				smlOutput.append(error.message)
 			}
 		}
 	}
 }
 
-function stop(){
+function restartREPL() {
+	//stop interpreter
+	sml.stdin.write("\0x26");
+	//stop cmdline
+	sml.stdin.end();	
+	//start again
+	start();
+}
+
+function stop() {
 	sml.stdin.end();
 }
 
 module.exports = {
 	start,
 	stop,
-	execShortCode
+	execShortCode,
+	restartREPL
 }

--- a/smlEnvironmentManager.js
+++ b/smlEnvironmentManager.js
@@ -11,15 +11,11 @@ function start() {
 
 	var cwd = {};
 	if (vscode.workspace.workspaceFolders !== undefined) {
-		var wd = vscode.workspace.workspaceFolders[0].uri.path;
-
-		//may start with / for some reason
-		if(wd[0] === '/')
-			wd = wd.substr(1, cwd.length);
+		var wd = vscode.workspace.workspaceFolders[0].uri.fsPath;
 
 		console.log("setting path to: " + wd)
 
-		cwd = {cwd: wd};
+		cwd = { cwd: wd };
 	}
 	else {
 		console.log("Unable to set working directory, no current workspace folder")
@@ -74,11 +70,10 @@ async function execShortCode() {
 }
 
 function restartREPL() {
-	//stop interpreter
-	sml.stdin.write("\0x26");
-	//stop cmdline
-	sml.stdin.end();	
-	//start again
+	if (sml.exitCode !== 0 && !sml.exitCode) {
+		sml.stdin.end();
+	}
+	sml.kill();
 	start();
 }
 


### PR DESCRIPTION
As far as I am aware you can't clear the REPL so if you encounter an syntax error the only solution is to restart the REPL. Until now, you had to restart vscode. Now you can access the command Restart SML REPL via the command pallate.

If vscode is open as a workspace then the path of the workspace directory will be used as the current working directory for the child process that starts sml. For some reason the string returned by vscode.workspace.workspaceFolders[0].uri.path starts with a \ character and I substring it out if it exists.

This is untested on Linux or macOS and works on my Windows 10 machine. Appreciative if someone can test this on macOS. I will boot up a Linux VM eventually unless someone beats me to it.