### PR TITLE
Text highlight

### DIFF
--- a/syntax/sml.tmLanguage.json
+++ b/syntax/sml.tmLanguage.json
@@ -349,9 +349,9 @@
 				"match": "(?!=(?<=[^:!?'@/\\-\\*\\\\\\+\\|&#%`^<=>~$])\\|(?=[^:!?'@/\\-\\*\\\\\\+\\|&#%`^<=>~$]))[:!?'@/\\-\\*\\\\\\+\\|&#%`^<=>~$]+",
 				"name": "variable.other.class.js message.error variable.interpolation string.regexp"
 			  },
-				{
-					"include": "#exp"
-				}
+			  {
+				"include": "#exp"
+			  }
 			]
 		  },
 		  {
@@ -952,9 +952,9 @@
 			"match": "(?=[[:upper:]])(?!=\\b(?:abstype|and|andalso|as|case|datatype|do|else|end|eqtype|exception|false|fn|fun|functor|handle|if|in|infix|infixr|include|let|local|nonfix|of|op|open|orelse|raise|rec|sharing|sig|signature|struct|structure|then|true|type|val|where|while|with|withtype)\\b)\\b[[:alpha:]][[:alnum:]'_]*(?:\\b|(?=[[:space:]]))",
 			"name": "entity.name.class constant.numeric"
 		  },
-			{
-				"include": "#exp"
-			}
+		  {
+			"include": "#exp"
+		  }
 		]
 	  },
 	  "qualifiedPrefix": {
@@ -1362,9 +1362,9 @@
 		  {
 			"include": "#fundec"
 		  },
-			{
-				"include": "#exp"
-			}
+		  {
+			"include": "#exp"
+		  }
 		]
 	  },
 	  "ty": {

--- a/syntax/sml.tmLanguage.json
+++ b/syntax/sml.tmLanguage.json
@@ -348,7 +348,10 @@
 			  {
 				"match": "(?!=(?<=[^:!?'@/\\-\\*\\\\\\+\\|&#%`^<=>~$])\\|(?=[^:!?'@/\\-\\*\\\\\\+\\|&#%`^<=>~$]))[:!?'@/\\-\\*\\\\\\+\\|&#%`^<=>~$]+",
 				"name": "variable.other.class.js message.error variable.interpolation string.regexp"
-			  }
+			  },
+				{
+					"include": "#exp"
+				}
 			]
 		  },
 		  {

--- a/syntax/sml.tmLanguage.json
+++ b/syntax/sml.tmLanguage.json
@@ -948,7 +948,10 @@
 		  {
 			"match": "(?=[[:upper:]])(?!=\\b(?:abstype|and|andalso|as|case|datatype|do|else|end|eqtype|exception|false|fn|fun|functor|handle|if|in|infix|infixr|include|let|local|nonfix|of|op|open|orelse|raise|rec|sharing|sig|signature|struct|structure|then|true|type|val|where|while|with|withtype)\\b)\\b[[:alpha:]][[:alnum:]'_]*(?:\\b|(?=[[:space:]]))",
 			"name": "entity.name.class constant.numeric"
-		  }
+		  },
+			{
+				"include": "#exp"
+			}
 		]
 	  },
 	  "qualifiedPrefix": {
@@ -1355,7 +1358,10 @@
 		  },
 		  {
 			"include": "#fundec"
-		  }
+		  },
+			{
+				"include": "#exp"
+			}
 		]
 	  },
 	  "ty": {


### PR DESCRIPTION
Fixing the text highlighting for the following points:
- a SML code did not can starts with comments
- after an `open`, a function call was not colored.