### PR TITLE
Scroll the terminal to bottom after code execution

### DIFF
--- a/smlEnvironmentManager.js
+++ b/smlEnvironmentManager.js
@@ -1,89 +1,93 @@
-const spawn = require('child_process').spawn;
-const vscode = require('vscode');
+const spawn = require("child_process").spawn;
+const vscode = require("vscode");
 
 let sml;
 const smlOutput = vscode.window.createOutputChannel("SML");
 let allowNextCommand;
 
 function start() {
-	allowNextCommand = false;
-	const interpreter = vscode.workspace.getConfiguration().get("sml-environment-interpreter-path", "sml")
+  allowNextCommand = false;
+  const interpreter = vscode.workspace
+    .getConfiguration()
+    .get("sml-environment-interpreter-path", "sml");
 
-	var cwd = {};
-	if (vscode.workspace.workspaceFolders !== undefined) {
-		var wd = vscode.workspace.workspaceFolders[0].uri.fsPath;
+  var cwd = {};
+  if (vscode.workspace.workspaceFolders !== undefined) {
+    var wd = vscode.workspace.workspaceFolders[0].uri.fsPath;
 
-		console.log("setting path to: " + wd)
+    console.log("setting path to: " + wd);
 
-		cwd = { cwd: wd };
-	}
-	else {
-		console.log("Unable to set working directory, no current workspace folder")
-	}
+    cwd = { cwd: wd };
+  } else {
+    console.log("Unable to set working directory, no current workspace folder");
+  }
 
-	sml = spawn(interpreter, [], Object.assign({ shell: true }, cwd));
+  sml = spawn(interpreter, [], Object.assign({ shell: true }, cwd));
 
-	sml.stdin.setEncoding('utf-8');
-	sml.stdout.setEncoding('utf-8');
-	sml.stderr.setEncoding('utf-8');
-	console.log('started');
-	sml.stdin.read(0);
+  sml.stdin.setEncoding("utf-8");
+  sml.stdout.setEncoding("utf-8");
+  sml.stderr.setEncoding("utf-8");
+  console.log("started");
+  sml.stdin.read(0);
 
-	sml.on('error', function (err) {
-		console.log(err);
-		smlOutput.append(err.message)
-	})
+  sml.on("error", function (err) {
+    console.log(err);
+    smlOutput.append(err.message);
+  });
 
-	sml.stderr.on('data', (data) => {
-		smlOutput.show(false);
-		smlOutput.append(data + `\n`);
-		allowNextCommand = true;
-	});
+  sml.stderr.on("data", (data) => {
+    smlOutput.show(false);
+    smlOutput.append(data + `\n`);
+    allowNextCommand = true;
+  });
 
-	sml.stdout.on('data', (data) => {
-		smlOutput.show(false);
-		smlOutput.append(data + `\n`);
-	});
-	smlOutput.show(false);
+  sml.stdout.on("data", (data) => {
+    smlOutput.show(false);
+    smlOutput.append(data + `\n`);
+  });
+  smlOutput.show(false);
 }
 
 async function execShortCode() {
-	while (!sml && !allowNextCommand) { ; }
-	const editor = vscode.window.activeTextEditor;
+  while (!sml && !allowNextCommand) {}
+  const editor = vscode.window.activeTextEditor;
 
-	if (editor) {
-		const document = editor.document;
-		const selection = editor.selection;
+  if (editor) {
+    const document = editor.document;
+    const selection = editor.selection;
 
-		const code = document.getText(selection);
-		if (sml.exitCode === 0 || sml.exitCode)
-			vscode.window.showErrorMessage("SML process died")
-		else {
-			try {
-				allowNextCommand = false;
-				sml.stdin.write(code + ';;;;\r\n');
-			} catch (error) {
-				smlOutput.append(error.message)
-			}
-		}
-	}
+    const code = document.getText(selection);
+    if (sml.exitCode === 0 || sml.exitCode)
+      vscode.window.showErrorMessage("SML process died");
+    else {
+      try {
+        allowNextCommand = false;
+        sml.stdin.write(code + ";;;;\r\n");
+      } catch (error) {
+        smlOutput.append(error.message);
+      }
+    }
+    await vscode.commands.executeCommand(
+      "workbench.action.terminal.scrollToBottom"
+    );
+  }
 }
 
 function restart() {
-	if (sml.exitCode !== 0 && !sml.exitCode) {
-		sml.stdin.end();
-	}
-	sml.kill();
-	start();
+  if (sml.exitCode !== 0 && !sml.exitCode) {
+    sml.stdin.end();
+  }
+  sml.kill();
+  start();
 }
 
 function stop() {
-	sml.stdin.end();
+  sml.stdin.end();
 }
 
 module.exports = {
-	start,
-	stop,
-	restart,
-	execShortCode
-}
+  start,
+  stop,
+  restart,
+  execShortCode,
+};


### PR DESCRIPTION
Scrolls the Integrated Terminal to the bottom after code execution.

It resolves next problem:
If you execute selected code and scroll up the terminal window and after that execute code again then terminal is not scrolled down to the bottom to see the result of the latest code run