### PR TITLE
Highlight comments inside let, allow names starting with `of`, and handle string escapes (fixes #12, #13, #15)

### DIFF
--- a/syntax/sml.tmLanguage.json
+++ b/syntax/sml.tmLanguage.json
@@ -75,6 +75,9 @@
 				"patterns": [
 				  {
 					"include": "#dec"
+				  },
+				  {
+					"include": "#comment"
 				  }
 				]
 			  },
@@ -259,7 +262,7 @@
 		"name": "string.double",
 		"patterns": [
 		  {
-			"match": "\\\\\""
+			"match": "(?x)\\\\(?:[\"\\\\abtnvfr]|[0-9]{3}|\\^[@-_]|u[0-9a-fA-F]{4}|[^\\\\]*\\\\)"
 		  }
 		]
 	  },
@@ -521,7 +524,7 @@
 				]
 			  },
 			  {
-				"begin": "(?<=[^[:word:]]of|^of)",
+				"begin": "(?<=[^[:word:]]of|^of)(?=[^[:word:]])",
 				"end": "(?=,|\\}|\\)|\\]|\\b(?:abstype|and|datatype|exception|fun|infix|infixr|local|nonfix|open|type|val|include|local|functor|signature|structure|end|in)\\b(?:$|[[:space:]]|(?<=[^:!?'@/\\-\\*\\\\\\+\\|&#%`^<=>~$]),|\\}|\\)|\\](?=[^:!?'@/\\-\\*\\\\\\+\\|&#%`^<=>~$])))",
 				"endCaptures": {
 				  "0": {


### PR DESCRIPTION
This fixes a few issues with syntax highlighting.

### BEFORE
<img width="667" alt="Screen Shot 2022-01-30 at 4 47 46 PM" src="https://user-images.githubusercontent.com/3360515/151719326-9285afe5-e998-4a66-ac54-b165b7fb433d.png">

### AFTER
<img width="667" alt="Screen Shot 2022-01-30 at 4 48 03 PM" src="https://user-images.githubusercontent.com/3360515/151719332-bf0d8741-c16d-4f8e-afed-9b620f406fe8.png">

